### PR TITLE
Fixed a problem that prevented detection of revision changes

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,7 +37,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/controllers/website_controller.go
+++ b/controllers/website_controller.go
@@ -102,7 +102,7 @@ func (r *WebSiteReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	if isUpdatedAtLeastOnce {
+	if isUpdatedAtLeastOnce || webSite.Status.Ready == corev1.ConditionFalse {
 		webSite.Status.Ready = corev1.ConditionTrue
 		webSite.Status.Revision = revision
 		errUpdate := r.client.Status().Update(ctx, webSite)


### PR DESCRIPTION
When temporarily unable to connect to repo-checker, `ready` becomes false.
However, even if the repo-checker is recovered, `ready` will not become true.
As a result, revision-watcher will not notify of revision changes.