### PR TITLE
Update: Ubuntu version from 20.04 to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zoetrope/ubuntu:20.04
+FROM ghcr.io/zoetrope/ubuntu:24.04
 
 LABEL org.opencontainers.image.source https://github.com/zoetrope/website-operator
 

--- a/Dockerfile.repo-checker
+++ b/Dockerfile.repo-checker
@@ -1,4 +1,4 @@
-FROM ghcr.io/zoetrope/ubuntu:20.04
+FROM ghcr.io/zoetrope/ubuntu:24.04
 
 LABEL org.opencontainers.image.source https://github.com/zoetrope/website-operator
 

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM ghcr.io/zoetrope/ubuntu:20.04
+FROM ghcr.io/zoetrope/ubuntu:24.04
 
 LABEL org.opencontainers.image.source https://github.com/zoetrope/website-operator
 

--- a/controllers/website_controller_test.go
+++ b/controllers/website_controller_test.go
@@ -376,7 +376,7 @@ metadata:
 spec:
   containers:
   - name: ubuntu
-    image: ghcr.io/zoetrope/ubuntu:20.04
+    image: ghcr.io/zoetrope/ubuntu:24.04
     command: ["/usr/local/bin/pause"]
 `,
 			}


### PR DESCRIPTION
## Overview
- Support ubuntu-24.04
- [Ubuntu 20.04 LTSの提供終了](https://jp.ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-jp)