### PR TITLE
Update ghcr.io/cybozu-go/website-operator

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,118 +43,68 @@ builds:
 before:
   hooks:
     - make frontend
-dockers:
-  - image_templates:
-      - "ghcr.io/cybozu-go/website-operator:{{ .Version }}-amd64"
-    use: buildx
+dockers_v2:
+  - id: website-operator
     dockerfile: ./Dockerfile
     ids:
       - website-operator
     extra_files:
       - LICENSE
-    build_flag_templates:
+    images:
+      - "ghcr.io/cybozu-go/website-operator"
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Major }}.{{ .Minor }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+    flags:
       - "--target=website-operator"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - image_templates:
-      - "ghcr.io/cybozu-go/website-operator:{{ .Version }}-arm64"
-    use: buildx
-    dockerfile: ./Dockerfile
-    ids:
-      - website-operator
-    extra_files:
-      - LICENSE
-    build_flag_templates:
-      - "--target=website-operator"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - image_templates:
-      - "ghcr.io/cybozu-go/website-operator-ui:{{ .Version }}-amd64"
-    use: buildx
+  - id: website-operator-ui
     dockerfile: ./Dockerfile
     ids:
       - website-operator-ui
     extra_files:
       - LICENSE
       - ui/frontend/dist
-    build_flag_templates:
+    images:
+      - "ghcr.io/cybozu-go/website-operator-ui"
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Major }}.{{ .Minor }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+    flags:
       - "--target=ui"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - image_templates:
-      - "ghcr.io/cybozu-go/website-operator-ui:{{ .Version }}-arm64"
-    use: buildx
-    dockerfile: ./Dockerfile
-    ids:
-      - website-operator-ui
-    extra_files:
-      - LICENSE
-      - ui/frontend/dist
-    build_flag_templates:
-      - "--target=ui"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - image_templates:
-    - "ghcr.io/cybozu-go/repo-checker:{{ .Version }}-amd64"
-    use: buildx
+  - id: repo-checker
     dockerfile: ./Dockerfile
     ids:
       - repo-checker
     extra_files:
       - LICENSE
-    build_flag_templates:
+    images:
+      - "ghcr.io/cybozu-go/repo-checker"
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Major }}.{{ .Minor }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+    flags:
       - "--target=repo-checker"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - image_templates:
-      - "ghcr.io/cybozu-go/repo-checker:{{ .Version }}-arm64"
-    use: buildx
-    dockerfile: ./Dockerfile
-    ids:
-      - repo-checker
-    extra_files:
-      - LICENSE
-    build_flag_templates:
-      - "--target=repo-checker"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-docker_manifests:
-  - name_template: "ghcr.io/cybozu-go/website-operator:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/cybozu-go/website-operator:{{ .Version }}-amd64"
-      - "ghcr.io/cybozu-go/website-operator:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/cybozu-go/website-operator:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/cybozu-go/website-operator:{{ .Version }}-amd64"
-      - "ghcr.io/cybozu-go/website-operator:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/cybozu-go/website-operator-ui:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/cybozu-go/website-operator-ui:{{ .Version }}-amd64"
-      - "ghcr.io/cybozu-go/website-operator-ui:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/cybozu-go/website-operator-ui:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/cybozu-go/website-operator-ui:{{ .Version }}-amd64"
-      - "ghcr.io/cybozu-go/website-operator-ui:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/cybozu-go/repo-checker:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/cybozu-go/repo-checker:{{ .Version }}-amd64"
-      - "ghcr.io/cybozu-go/repo-checker:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/cybozu-go/repo-checker:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/cybozu-go/repo-checker:{{ .Version }}-amd64"
-      - "ghcr.io/cybozu-go/repo-checker:{{ .Version }}-arm64"
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/zoetrope/ubuntu:22.04 as base
 
-LABEL org.opencontainers.image.source=https://github.com/zoetrope/website-operator
+LABEL org.opencontainers.image.source=https://github.com/cybozu-go/website-operator
 
 FROM base as website-operator
 COPY website-operator /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM ghcr.io/cybozu/ubuntu:24.04 as base
+FROM ghcr.io/cybozu/ubuntu:24.04 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/cybozu-go/website-operator
 
-FROM base as website-operator
+FROM base AS website-operator
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/website-operator /
 USER 10000:10000
 ENTRYPOINT ["/website-operator"]
 
-FROM base as repo-checker
+FROM base AS repo-checker
 ARG TARGETPLATFORM
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git openssh-client \
@@ -17,7 +17,7 @@ COPY $TARGETPLATFORM/repo-checker /
 USER 10000:10000
 ENTRYPOINT ["/repo-checker"]
 
-FROM base as ui
+FROM base AS ui
 ARG TARGETPLATFORM
 COPY ui/frontend/dist /dist
 COPY $TARGETPLATFORM/website-operator-ui /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cybozu/ubuntu:22.04 as base
+FROM ghcr.io/cybozu/ubuntu:24.04 as base
 
 LABEL org.opencontainers.image.source=https://github.com/cybozu-go/website-operator
 
@@ -8,6 +8,9 @@ USER 10000:10000
 ENTRYPOINT ["/website-operator"]
 
 FROM base as repo-checker
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 COPY repo-checker /
 USER 10000:10000
 ENTRYPOINT ["/repo-checker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,23 @@ FROM ghcr.io/cybozu/ubuntu:24.04 as base
 LABEL org.opencontainers.image.source=https://github.com/cybozu-go/website-operator
 
 FROM base as website-operator
-COPY website-operator /
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/website-operator /
 USER 10000:10000
 ENTRYPOINT ["/website-operator"]
 
 FROM base as repo-checker
+ARG TARGETPLATFORM
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git openssh-client \
     && rm -rf /var/lib/apt/lists/*
-COPY repo-checker /
+COPY $TARGETPLATFORM/repo-checker /
 USER 10000:10000
 ENTRYPOINT ["/repo-checker"]
 
 FROM base as ui
+ARG TARGETPLATFORM
 COPY ui/frontend/dist /dist
-COPY website-operator-ui /
+COPY $TARGETPLATFORM/website-operator-ui /
 USER 10000:10000
 ENTRYPOINT ["/website-operator-ui"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zoetrope/ubuntu:22.04 as base
+FROM ghcr.io/cybozu/ubuntu:22.04 as base
 
 LABEL org.opencontainers.image.source=https://github.com/cybozu-go/website-operator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source=https://github.com/cybozu-go/website-opera
 FROM base AS website-operator
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/website-operator /
-USER 10000:10000
+USER 1000:1000
 ENTRYPOINT ["/website-operator"]
 
 FROM base AS repo-checker
@@ -14,12 +14,12 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git openssh-client \
     && rm -rf /var/lib/apt/lists/*
 COPY $TARGETPLATFORM/repo-checker /
-USER 10000:10000
+USER 1000:1000
 ENTRYPOINT ["/repo-checker"]
 
 FROM base AS ui
 ARG TARGETPLATFORM
 COPY ui/frontend/dist /dist
 COPY $TARGETPLATFORM/website-operator-ui /
-USER 10000:10000
+USER 1000:1000
 ENTRYPOINT ["/website-operator-ui"]

--- a/charts/website-operator/values.yaml
+++ b/charts/website-operator/values.yaml
@@ -1,6 +1,6 @@
 controller:
   image:
-    repository: ghcr.io/zoetrope/website-operator
+    repository: ghcr.io/cybozu-go/website-operator
     tag: app-version-placeholder
   replicas: 1
   config:
@@ -13,7 +13,7 @@ controller:
       bindAddress: 127.0.0.1:8080
 ui:
   image:
-    repository: ghcr.io/zoetrope/website-operator-ui
+    repository: ghcr.io/cybozu-go/website-operator-ui
     tag: app-version-placeholder
   replicas: 1
   service:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,8 +31,8 @@ spec:
             - /website-operator
           args:
             - --leader-elect
-            - --repochecker-container-image=ghcr.io/zoetrope/repo-checker:dev
-          image: ghcr.io/zoetrope/website-operator:dev
+            - --repochecker-container-image=ghcr.io/cybozu-go/repo-checker:dev
+          image: ghcr.io/cybozu-go/website-operator:dev
           name: manager
           securityContext:
             allowPrivilegeEscalation: false

--- a/config/release/manager.yaml
+++ b/config/release/manager.yaml
@@ -11,5 +11,5 @@ spec:
             - /website-operator
           args:
             - --leader-elect
-          image: ghcr.io/zoetrope/website-operator:dev
+          image: ghcr.io/cybozu-go/website-operator:dev
           name: manager

--- a/config/release/ui.yaml
+++ b/config/release/ui.yaml
@@ -11,5 +11,5 @@ spec:
             - /website-operator-ui
           args:
             - --allow-cors=false
-          image: ghcr.io/zoetrope/website-operator-ui:dev
+          image: ghcr.io/cybozu-go/website-operator-ui:dev
           name: ui

--- a/config/ui/ui.yaml
+++ b/config/ui/ui.yaml
@@ -20,7 +20,7 @@ spec:
             - /website-operator-ui
           args:
             - --allow-cors=true
-          image: ghcr.io/zoetrope/website-operator-ui:dev
+          image: ghcr.io/cybozu-go/website-operator-ui:dev
           name: ui
           ports:
             - name: http

--- a/controllers/website_controller.go
+++ b/controllers/website_controller.go
@@ -347,8 +347,8 @@ func (r *WebSiteReconciler) makePodTemplateForRepoChecker(webSite *websitev1beta
 	}
 
 	newTemplate.Spec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsUser: ptr.To[int64](10000),
-		FSGroup:   ptr.To[int64](10000),
+		RunAsUser: ptr.To[int64](1000),
+		FSGroup:   ptr.To[int64](1000),
 	}
 
 	if webSite.Spec.DeployKeySecretName != nil {
@@ -550,7 +550,7 @@ func (r *WebSiteReconciler) makeNginxPodTemplate(ctx context.Context, webSite *w
 		)
 	}
 	newTemplate.Spec.SecurityContext = &corev1.PodSecurityContext{
-		FSGroup: ptr.To[int64](10000),
+		FSGroup: ptr.To[int64](1000),
 	}
 
 	newTemplate.Spec.Containers = append(newTemplate.Spec.Containers, corev1.Container{
@@ -603,7 +603,7 @@ func (r *WebSiteReconciler) makeNginxPodTemplate(ctx context.Context, webSite *w
 		Image:   webSite.Spec.BuildImage,
 		Command: []string{"/bin/bash", "-c", "/build/" + BuildScriptName + ".sh"},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: ptr.To[int64](10000),
+			RunAsUser: ptr.To[int64](1000),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -899,14 +899,14 @@ func (r *WebSiteReconciler) reconcileAfterBuildScript(ctx context.Context, webSi
 		)
 	}
 	template.Spec.SecurityContext = &corev1.PodSecurityContext{
-		FSGroup: ptr.To[int64](10000),
+		FSGroup: ptr.To[int64](1000),
 	}
 	buildContainer := corev1.Container{
 		Name:    "job",
 		Image:   webSite.Spec.BuildImage,
 		Command: []string{"/bin/bash", "-c", "/after-build/" + AfterBuildScriptName + ".sh"},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: ptr.To[int64](10000),
+			RunAsUser: ptr.To[int64](1000),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/controllers/website_controller_test.go
+++ b/controllers/website_controller_test.go
@@ -376,7 +376,7 @@ metadata:
 spec:
   containers:
   - name: ubuntu
-    image: ghcr.io/zoetrope/ubuntu:22.04
+    image: ghcr.io/cybozu/ubuntu:22.04
     command: ["/usr/local/bin/pause"]
 `,
 			}

--- a/controllers/website_controller_test.go
+++ b/controllers/website_controller_test.go
@@ -376,7 +376,7 @@ metadata:
 spec:
   containers:
   - name: ubuntu
-    image: ghcr.io/cybozu/ubuntu:22.04
+    image: ghcr.io/cybozu/ubuntu:24.04
     command: ["/usr/local/bin/pause"]
 `,
 			}
@@ -481,6 +481,7 @@ spec:
 			site := newWebSite().withRawBuildScript().withAfterBuildScript().build()
 			err := k8sClient.Create(ctx, site)
 			Expect(err).NotTo(HaveOccurred())
+
 
 			job := batchv1.Job{}
 			Eventually(func() error {

--- a/controllers/website_controller_test.go
+++ b/controllers/website_controller_test.go
@@ -482,7 +482,6 @@ spec:
 			err := k8sClient.Create(ctx, site)
 			Expect(err).NotTo(HaveOccurred())
 
-
 			job := batchv1.Job{}
 			Eventually(func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{Namespace: "test", Name: "mysite"}, &job)

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -28,7 +28,7 @@ test: launch-kind load-images setup-cluster
 .PHONY: load-images
 load-images:
 	cd ../ && cat .goreleaser.yml \
-	  | PLATFORM="linux/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" \
+	  | PLATFORM="linux/$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" \
 	    yq '(.dockers_v2[].platforms) |= map(select(. == env(PLATFORM)))' \
 	  | goreleaser release -f - --clean --snapshot --skip=publish
 	ID=$$(docker image inspect --format='{{.ID}}' $(REGISTRY)website-operator:dev-amd64); \

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -27,7 +27,10 @@ test: launch-kind load-images setup-cluster
 
 .PHONY: load-images
 load-images:
-	cd ../ && goreleaser release --clean --snapshot --skip=publish
+	cd ../ && cat .goreleaser.yml \
+	  | PLATFORM="linux/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" \
+	    yq '(.dockers_v2[].platforms) |= map(select(. == env(PLATFORM)))' \
+	  | goreleaser release -f - --clean --snapshot --skip=publish
 	ID=$$(docker image inspect --format='{{.ID}}' $(REGISTRY)website-operator:dev-amd64); \
 	if [ ! "$$(docker exec -it $(KIND_CLUSTER_NAME)-control-plane ctr --namespace=k8s.io images list | grep $$ID)" ]; then \
 		kind load docker-image --name=$(KIND_CLUSTER_NAME) $(REGISTRY)website-operator:dev-amd64; \

--- a/e2e/manifests/manager/ui.yaml
+++ b/e2e/manifests/manager/ui.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: ui
-          image: ghcr.io/zoetrope/website-operator-ui:dev-amd64
+          image: ghcr.io/cybozu-go/website-operator-ui:dev-amd64


### PR DESCRIPTION
Following the transfer of website-operator, the location for ghcr.io has changed to ghcr.io/cybozu-go/website-operator, so I have updated the references accordingly.
https://github.com/cybozu-go/website-operator/pkgs/container/website-operator

In addition, since there was an in-house container for ubuntu, I have updated that as well.

For this PR, I have only made the changes that can be easily addressed for now, and I plan to handle the API and CRD-related changes in a separate PR.