### PR TITLE
Add SHA256 hashes to Docker images and update Kubernetes version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zoetrope/ubuntu:22.04 as base
+FROM ghcr.io/zoetrope/ubuntu:22.04@sha256:399e56354efe531e98f618966249767814d0d4ee6260bb4cf4086a0b45531979 as base
 
 LABEL org.opencontainers.image.source=https://github.com/zoetrope/website-operator
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,19 +1,19 @@
 load('ext://restart_process', 'docker_build_with_restart')
 
-OPERATOR_DOCKERFILE = '''FROM golang:alpine
+OPERATOR_DOCKERFILE = '''FROM golang:alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1
 WORKDIR /
 COPY ./bin/website-operator /
 CMD ["/website-operator"]
 '''
 
-REPOCHECKER_DOCKERFILE = '''FROM golang:alpine
+REPOCHECKER_DOCKERFILE = '''FROM golang:alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1
 RUN apk update && apk add git
 WORKDIR /
 COPY ./bin/repo-checker /
 CMD ["/repo-checker"]
 '''
 
-UI_DOCKERFILE = '''FROM golang:alpine
+UI_DOCKERFILE = '''FROM golang:alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1
 WORKDIR /
 COPY ./ui/frontend/dist/* /dist/
 COPY ./bin/website-operator-ui /

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION := v1.34.3 # renovate: kindest/node
+KUBERNETES_VERSION := v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48 # renovate: kindest/node
 REGISTRY := ghcr.io/cybozu-go/
 KIND_CLUSTER_NAME=website-e2e
 


### PR DESCRIPTION
I have not touched the line in the Makefile where GOBIN=$(BIN_DIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest is specified, because that line will be removed once https://github.com/cybozu-go/website-operator/pull/713 is merged. From the perspective of CI, the merge order will definitely be after 713, so I will handle it by rebasing.