### PR TITLE
clarify permissions on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ jobs:
   test:
     name: Small test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -28,6 +30,8 @@ jobs:
   e2e:
     name: End-to-end Test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         k8s-version:
@@ -69,11 +73,14 @@ jobs:
     name: All e2e tests passed
     runs-on: ubuntu-latest
     needs: e2e
+    permissions: {}
     steps:
       - run: echo ok
   check-goreleaser-config:
     name: Check goreleaser.yml
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -86,6 +93,8 @@ jobs:
   tilt:
     name: Run tilt ci
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -110,6 +119,8 @@ jobs:
   dry-run:
     name: Dry-run release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -51,6 +54,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: release
     if: contains(needs.release.result, 'success')
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
As part of our efforts to strengthen security, our team is implementing a policy to set the default authentication token permissions for GitHub Actions to read-only.

To accommodate this, workflows that require additional permissions must explicitly declare them.

After this change is merged, we plan to restrict the default permissions to read-only via the repository settings.