### PR TITLE
fix workflow to push builder images properly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,20 +111,20 @@ jobs:
       - name: Check builder images existence
         id: check_existence
         env:
-          IMAGE: website-operator-${{ matrix.image }}
+          IMAGE: ghcr.io/cybozu-go/website-operator-${{ matrix.image }}
           TAG: ${{ steps.get_tags.outputs.TAG }}
         run: |
           # This command returns 1 when the manifest does not exist, but it can also return 1 for other errors (e.g., network issues).
           # To avoid false negatives, we check the output message.
           set +e
-          INSPECT_OUTPUT=$(docker manifest inspect "ghcr.io/${{ github.repository }}/${IMAGE}:${TAG}" 2>&1)
-          set -e
+          INSPECT_OUTPUT=$(docker manifest inspect "${IMAGE}:${TAG}" 2>&1)
           EXIT_CODE=$?
+          set -e
           if [ $EXIT_CODE -eq 0 ]; then
-            echo "Image ghcr.io/cybozu-go/${IMAGE}:${TAG} already exists. Skipping push."
+            echo "Image ${IMAGE}:${TAG} already exists. Skipping push."
             echo "exists=true" >> "$GITHUB_OUTPUT"
           elif echo "${INSPECT_OUTPUT}" | grep -qE "manifest unknown"; then
-            echo "Image ghcr.io/cybozu-go/${IMAGE}:${TAG} does not exist. It will be pushed when the branch is main."
+            echo "Image ${IMAGE}:${TAG} does not exist. It will be pushed when the branch is main."
             echo "exists=false" >> "$GITHUB_OUTPUT"
           else
             echo "Failed to check image existence: ${INSPECT_OUTPUT}"


### PR DESCRIPTION
The branching logic based on the success or failure of the previous command was not working correctly.


I intentionally executed `set +e` and `set -e` to prevent the entire step from failing due to a command failure.


However, this caused the result of `$?` to be overwritten, resulting in the command always being treated as successful.